### PR TITLE
Fix parse api

### DIFF
--- a/lib/bank_account.ex
+++ b/lib/bank_account.ex
@@ -75,7 +75,7 @@ defmodule Ofex.BankAccount do
   <!-- </BANKMSGSRSV1> -->
   ```
   """
-  @spec create(binary) :: {:bank_account, %{}}
+  @spec create(binary) :: {:account, %{}}
   def create(ofx_data) do
     account = %{
       account_number: xpath(ofx_data, ~x"//ACCTID/text()"s),
@@ -93,7 +93,7 @@ defmodule Ofex.BankAccount do
       type: xpath(ofx_data, ~x"//ACCTTYPE/text()"s),
     }
 
-    {:bank_account, account}
+    %{account: account}
   end
 
   defp generic_type_from_type("MONEYMRKT"), do: "SAVINGS"

--- a/lib/credit_card_account.ex
+++ b/lib/credit_card_account.ex
@@ -3,6 +3,7 @@ defmodule Ofex.CreditCardAccount do
   import Ofex.Helpers
   import SweetXml
 
+  @spec create(binary) :: %{account: %{}}
   def create(ofx_data) do
     account = %{
       request_id: xpath(ofx_data, ~x"//TRNUID/text()"s),
@@ -18,7 +19,7 @@ defmodule Ofex.CreditCardAccount do
       type: "CREDIT_CARD"
     }
 
-    {:credit_card_account, account}
+    %{account: account}
   end
 
   defp parse_transactions(ofx_transactions) do

--- a/lib/ofex.ex
+++ b/lib/ofex.ex
@@ -51,16 +51,16 @@ defmodule Ofex do
         |> xpath(~x"//OFX/*[contains(name(),'MSGSRS')]"l)
         |> Enum.map(&parse_message_set(xpath(&1, ~x"name()"s), &1))
         |> List.flatten
-        |> Enum.reduce(%{signon: %{}, accounts: []}, &reduce_items_list/2)
+        |> Enum.reduce(%{signon: %{}, accounts: []}, &accumulate_parsed_items/2)
 
         {:ok, result}
       {:error, message} -> {:error, %InvalidData{message: message, data: data}}
     end
   end
 
-  defp reduce_items_list(%{signon: signon}, %{accounts: accounts}), do: %{signon: signon, accounts: accounts}
-  defp reduce_items_list(%{account: account}, %{accounts: accounts}=acc), do: Map.put(acc, :accounts, [account | accounts])
-  defp reduce_items_list(_, acc), do: acc
+  defp accumulate_parsed_items(%{signon: signon}, %{accounts: accounts}), do: %{signon: signon, accounts: accounts}
+  defp accumulate_parsed_items(%{account: account}, %{accounts: accounts}=acc), do: Map.put(acc, :accounts, [account | accounts])
+  defp accumulate_parsed_items(_, acc), do: acc
 
   defp cleanup_whitespace(ofx_data) do
     ofx_data

--- a/lib/ofex.ex
+++ b/lib/ofex.ex
@@ -48,11 +48,10 @@ defmodule Ofex do
     case validate_ofx_data(data) do
       {:ok, parsed_ofx} ->
         result = parsed_ofx
-        |> xpath(~x"//OFX/*[contains(name(),'MSGSRS')]"l)
-        |> Enum.map(&parse_message_set(xpath(&1, ~x"name()"s), &1))
-        |> List.flatten
-        |> Enum.reduce(%{signon: %{}, accounts: []}, &accumulate_parsed_items/2)
-
+                 |> xpath(~x"//OFX/*[contains(name(),'MSGSRS')]"l)
+                 |> Enum.map(&parse_message_set(xpath(&1, ~x"name()"s), &1))
+                 |> List.flatten
+                 |> Enum.reduce(%{signon: %{}, accounts: []}, &accumulate_parsed_items/2)
         {:ok, result}
       {:error, message} -> {:error, %InvalidData{message: message, data: data}}
     end

--- a/lib/ofex.ex
+++ b/lib/ofex.ex
@@ -12,8 +12,7 @@ defmodule Ofex do
 
   `data` will need to be supplied as a string. Each message set of the OFX data is parsed
   separately and returned as map containing a `:signon` map and an `:accounts` list.
-    * `:accounts` Banking Message Set Response (_BANKMSGSRS_), (_CREDITCARDMSGSRS_), or (_SIGNUPMSGSR_)
-    via `Ofex.BankAccount` or `Ofex.CreditCardAccount`
+    * `:accounts` Message Set Response (_BANKMSGSRS_), (_CREDITCARDMSGSRS_), or (_SIGNUPMSGSR_) via `Ofex.BankAccount` or `Ofex.CreditCardAccount`
     * `:signon` Signon Message Set Response (_SIGNONMSGSRS_) via `Ofex.Signon`
 
   Parsing errors or invalid data will return a tuple of `{:error, %Ofex.InvalidData{}}` (see `Ofex.InvalidData`)
@@ -21,7 +20,7 @@ defmodule Ofex do
   ## Examples
 
       iex > Ofex.parse("<OFX>..actual_ofx_data...</OFX>")
-      %{signon: %{}, accounts: [%{}, %{}, %{}]}
+      %{signon: %{}, accounts: [%{}, %{}, ...}
 
       iex> Ofex.parse("I am definitely not OFX")
       {:error, %Ofex.InvalidData{message: "data provided cannot be parsed. May not be OFX format", data: "I am definitely not OFX"}}

--- a/lib/ofex.ex
+++ b/lib/ofex.ex
@@ -11,9 +11,9 @@ defmodule Ofex do
   Validates and parses Open Financial Exchange (OFX) data.
 
   `data` will need to be supplied as a string. Each message set of the OFX data is parsed
-  separately and returned as a map with the following keys:
-    * `:bank_account` Banking Message Set Response (_BANKMSGSRS_) via `Ofex.BankAccount`
-    * `:credit_card_account` Credit Card Message Set Response (_CREDITCARDMSGSRS_) via `Ofex.CreditCardAccount`
+  separately and returned as map containing a `:signon` map and an `:accounts` list.
+    * `:accounts` Banking Message Set Response (_BANKMSGSRS_), (_CREDITCARDMSGSRS_), or (_SIGNUPMSGSR_)
+    via `Ofex.BankAccount` or `Ofex.CreditCardAccount`
     * `:signon` Signon Message Set Response (_SIGNONMSGSRS_) via `Ofex.Signon`
 
   Parsing errors or invalid data will return a tuple of `{:error, %Ofex.InvalidData{}}` (see `Ofex.InvalidData`)
@@ -21,12 +21,13 @@ defmodule Ofex do
   ## Examples
 
       iex > Ofex.parse("<OFX>..actual_ofx_data...</OFX>")
-      %{bank_account: %{}, credit_card_account: %{}, signon: %{}, signon_accounts: [bank_account: %{}, ...]}
+      %{signon: %{}, accounts: [%{}, %{}, %{}]}
 
       iex> Ofex.parse("I am definitely not OFX")
       {:error, %Ofex.InvalidData{message: "data provided cannot be parsed. May not be OFX format", data: "I am definitely not OFX"}}
 
   ### Only strings are allowed to be passed in for parsing
+
       iex> Ofex.parse(1234)
       {:error, %Ofex.InvalidData{message: "data is not binary", data: 1234}}
 
@@ -47,13 +48,20 @@ defmodule Ofex do
   def parse(data) do
     case validate_ofx_data(data) do
       {:ok, parsed_ofx} ->
-        parsed_ofx
+        result = parsed_ofx
         |> xpath(~x"//OFX/*[contains(name(),'MSGSRS')]"l)
         |> Enum.map(&parse_message_set(xpath(&1, ~x"name()"s), &1))
-        |> Map.new
+        |> List.flatten
+        |> Enum.reduce(%{signon: %{}, accounts: []}, &reduce_items_list/2)
+
+        {:ok, result}
       {:error, message} -> {:error, %InvalidData{message: message, data: data}}
     end
   end
+
+  defp reduce_items_list(%{signon: signon}, %{accounts: accounts}), do: %{signon: signon, accounts: accounts}
+  defp reduce_items_list(%{account: account}, %{accounts: accounts}=acc), do: Map.put(acc, :accounts, [account | accounts])
+  defp reduce_items_list(_, acc), do: acc
 
   defp cleanup_whitespace(ofx_data) do
     ofx_data

--- a/lib/signon.ex
+++ b/lib/signon.ex
@@ -36,6 +36,6 @@ defmodule Ofex.Signon do
                        language: ~x"LANGUAGE/text()"s,
                        financial_institution: ~x"FI/ORG/text()"s,
                      )
-    {:signon, signon_details}
+    %{signon: signon_details}
   end
 end

--- a/lib/signon_accounts.ex
+++ b/lib/signon_accounts.ex
@@ -1,16 +1,15 @@
 defmodule Ofex.SignonAccounts do
   import SweetXml
 
+  @spec create(binary) :: [%{account: %{}}]
   def create(ofx_data) do
-    accounts = xpath(ofx_data, ~x"//ACCTINFO"l) |> Enum.map(&parse_account/1)
-    {:signon_accounts, accounts}
+    xpath(ofx_data, ~x"//ACCTINFO"l) |> Enum.map(&parse_account/1)
   end
 
-  def parse_account(account_data) do
-    account = case xpath(account_data, ~x"//CCACCTINFO"l) do
-                [] -> Ofex.BankAccount.create(account_data)
-                _match -> Ofex.CreditCardAccount.create(account_data)
-              end
-    Map.new([account])
+  defp parse_account(account_data) do
+    case xpath(account_data, ~x"//CCACCTINFO"l) do
+      [] -> Ofex.BankAccount.create(account_data)
+      _match -> Ofex.CreditCardAccount.create(account_data)
+    end
   end
 end

--- a/test/bank_account_test.exs
+++ b/test/bank_account_test.exs
@@ -4,7 +4,7 @@ defmodule Ofex.BankAccountTest do
   @ofx_raw File.read!("test/fixtures/banking_account.ofx")
 
   test "can parse banking account details" do
-    %{bank_account: account} = Ofex.parse(@ofx_raw)
+    {:ok, %{accounts: [account]}} = Ofex.parse(@ofx_raw)
     %{transactions: transactions} = account
 
     assert account == %{
@@ -25,7 +25,7 @@ defmodule Ofex.BankAccountTest do
   end
 
   test "can parse bank account transactions" do
-    %{bank_account: account} = Ofex.parse(@ofx_raw)
+    {:ok, %{accounts: [account]}} = Ofex.parse(@ofx_raw)
     %{transactions: transactions} = account
 
     assert transactions == [

--- a/test/credit_card_account_test.exs
+++ b/test/credit_card_account_test.exs
@@ -4,7 +4,7 @@ defmodule Ofex.CreditCardAccountTest do
   @ofx_raw File.read!("test/fixtures/credit_card_response.ofx")
 
   test "can parse credit card account details" do
-    %{credit_card_account: account} = Ofex.parse(@ofx_raw)
+    {:ok, %{accounts: [account]}} = Ofex.parse(@ofx_raw)
     %{transactions: transactions} = account
 
     assert account == %{
@@ -23,7 +23,7 @@ defmodule Ofex.CreditCardAccountTest do
   end
 
   test "can parse credit card transactions" do
-    %{credit_card_account: account} = Ofex.parse(@ofx_raw)
+    {:ok, %{accounts: [account]}} = Ofex.parse(@ofx_raw)
     %{transactions: transactions} = account
 
     assert transactions == [

--- a/test/ofex_test.exs
+++ b/test/ofex_test.exs
@@ -4,8 +4,9 @@ defmodule OfexTest do
 
   test "validates data is OFX" do
     ofx_raw = File.read!("test/fixtures/banking_account.ofx")
-    parsed = Ofex.parse(ofx_raw)
-    assert is_map(parsed) == true
+    {:ok, %{signon: signon, accounts: accounts}} = Ofex.parse(ofx_raw)
+    assert is_list(accounts)
+    assert is_map(signon)
   end
 
   test "returns an error if data provided is binary but not OFX" do
@@ -23,14 +24,11 @@ defmodule OfexTest do
 
   test "can parse data with missing closing tags" do
     ofx_raw = File.read!("test/fixtures/missing_closing_tags.ofx")
-    parsed = Ofex.parse(ofx_raw)
-    assert Map.has_key?(parsed, :signon)
+    {:ok, %{signon: _signon}} = Ofex.parse(ofx_raw)
   end
 
   test "can parse QFX data" do
     ofx_raw = File.read!("test/fixtures/bank_account.qfx")
-    parsed = Ofex.parse(ofx_raw)
-    assert Map.has_key?(parsed, :bank_account)
-    assert Map.has_key?(parsed, :signon)
+    {:ok, %{accounts: [_bank_account]}} = Ofex.parse(ofx_raw)
   end
 end

--- a/test/signon_accounts_test.exs
+++ b/test/signon_accounts_test.exs
@@ -3,7 +3,7 @@ defmodule Ofex.SignonAccountsTest do
 
   test "can parse banking and credit card accounts from a signon response" do
     ofx_raw = File.read!("test/fixtures/signon_accounts.ofx")
-    %{signon_accounts: [%{bank_account: bank_account}, %{credit_card_account: credit_card_account}]} = Ofex.parse(ofx_raw)
+    {:ok, %{accounts: [credit_card_account, bank_account]}} = Ofex.parse(ofx_raw)
 
     assert bank_account.name == "MY CHECKING ACCOUNT"
     assert credit_card_account.name == "Signature Visa"

--- a/test/signon_test.exs
+++ b/test/signon_test.exs
@@ -2,7 +2,7 @@ defmodule Ofex.SignonTest do
   use ExUnit.Case, async: true
 
   test "parses ofx doc signon response details" do
-    %{signon: signon} = Ofex.parse(File.read!("test/fixtures/banking_account.ofx"))
+    {:ok, %{signon: signon}} = Ofex.parse(File.read!("test/fixtures/banking_account.ofx"))
 
     assert signon == %{
       financial_institution: "Galactic CU",


### PR DESCRIPTION
This is a breaking change.

1. Instead of returning a hash, this will now return `{:ok, _}` to match the error/ reason pattern.
2. This changes `parse` to return `%{signon: %{}, accounts: [%{}, %{}, %{}, ...]}`.

Let me know what you think :).

cc @jjcarstens 