### PR TITLE
add transactions start/end date ranges to bank and credit_card accounts

### DIFF
--- a/lib/bank_account.ex
+++ b/lib/bank_account.ex
@@ -99,6 +99,8 @@ defmodule Ofex.BankAccount do
       {:status_code, xpath(ofx_data, ~x"//CODE/text()"s)},
       {:status_severity, xpath(ofx_data, ~x"//SEVERITY/text()"s)},
       {:transactions, ofx_data |> xpath(~x"//BANKTRANLIST/STMTTRN"l) |> parse_transactions},
+      {:transactions_end_date, xpath(ofx_data, ~x"//BANKTRANLIST/DTEND/text()"s)},
+      {:transactions_start_date, xpath(ofx_data, ~x"//BANKTRANLIST/DTSTART/text()"s)},
       {:type, xpath(ofx_data, ~x"//ACCTTYPE/text()"s)}
     ]
   end

--- a/lib/credit_card_account.ex
+++ b/lib/credit_card_account.ex
@@ -21,6 +21,8 @@ defmodule Ofex.CreditCardAccount do
       {:account_number, xpath(ofx_data, ~x"//ACCTID/text()"s)},
       {:name, xpath(ofx_data, ~x"//DESC/text()"s)},
       {:transactions, ofx_data |> xpath(~x"//BANKTRANLIST/STMTTRN"l) |> parse_transactions},
+      {:transactions_end_date, xpath(ofx_data, ~x"//BANKTRANLIST/DTEND/text()"s)},
+      {:transactions_start_date, xpath(ofx_data, ~x"//BANKTRANLIST/DTSTART/text()"s)},
       {:balance, xpath(ofx_data, ~x"//BALAMT/text()"s)},
       {:positive_balance, xpath(ofx_data, ~x"//BALAMT/text()"s)},
       {:balance_date, xpath(ofx_data, ~x"//DTASOF/text()"s)},

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -44,6 +44,14 @@ defmodule Ofex.Helpers do
     {:posted_date, string_to_date(date_str)}
   end
 
+  defp format_attribute_value({:transactions_end_date, date_str}) do
+    {:transactions_end_date, string_to_date(date_str)}
+  end
+
+  defp format_attribute_value({:transactions_start_date, date_str}) do
+    {:transactions_start_date, string_to_date(date_str)}
+  end
+
   defp format_attribute_value(attribute_tuple), do: attribute_tuple
 
   def string_to_date(date_str) when byte_size(date_str) == 8 do

--- a/test/bank_account_test.exs
+++ b/test/bank_account_test.exs
@@ -20,6 +20,8 @@ defmodule Ofex.BankAccountTest do
       status_code: "0",
       status_severity: "INFO",
       transactions: transactions,
+      transactions_end_date: ~D[2017-01-27],
+      transactions_start_date: ~D[1970-01-01],
       type: "CHECKING"
     }
   end

--- a/test/credit_card_account_test.exs
+++ b/test/credit_card_account_test.exs
@@ -18,6 +18,8 @@ defmodule Ofex.CreditCardAccountTest do
       status_code: "0",
       status_severity: "INFO",
       transactions: transactions,
+      transactions_end_date: ~D[2017-02-06],
+      transactions_start_date: ~D[1970-01-01],
       type: "CREDIT_CARD"
     }
   end


### PR DESCRIPTION
Resolves #11 

Adds `transactions_start_date` and `transactions_end_date` keys to account responses to indicate the range of transactions that the OFX server searched and subsequently returned transactions for.

See [OFX documentation: 3.2.7 Date Start and Date End <DTSTART> <DTEND](http://www.ofx.net/downloads/OFX%202.2.pdf)